### PR TITLE
Supports docker-compose version 2

### DIFF
--- a/src/main/groovy/org/stackwork/gradle/docker/tasks/RunDockerComposeTask.groovy
+++ b/src/main/groovy/org/stackwork/gradle/docker/tasks/RunDockerComposeTask.groovy
@@ -23,6 +23,10 @@ class RunDockerComposeTask extends AbstractTask {
     doLast {
       composeInfo = (Map<String, Object>) new Yaml().load(project.file(composeFile).text)
 
+	  if ("2"==composeInfo.get("version")) {
+	  	composeInfo = composeInfo.get("services")
+	  }
+
       List<String> allServices = new ArrayList<>()
       allServices.addAll(composeInfo.keySet())
 

--- a/src/test/gradle-projects/compose-root-project-version2/build.gradle
+++ b/src/test/gradle-projects/compose-root-project-version2/build.gradle
@@ -1,0 +1,17 @@
+import static org.stackwork.gradle.docker.ModuleType.*
+
+buildscript {
+  repositories {
+    maven { url = "file://${project.projectDir}/../../../../build/repoForTests" }
+    mavenCentral()
+  }
+  dependencies {
+    classpath group: 'org.stackwork.gradle', name: 'stackwork', version: '0.1-TEST'
+  }
+}
+apply from: '../../gradle-plugins/stackwork-extended-for-tests.gradle'
+
+stackwork {
+  moduleType = COMPOSE
+}
+

--- a/src/test/gradle-projects/compose-root-project-version2/docker-compose.yml
+++ b/src/test/gradle-projects/compose-root-project-version2/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  service:
+    image: qkrijger/hello-world-wiremock-server:0.1.0-SNAPSHOT
+    ports:
+    - 80

--- a/src/test/gradle-projects/compose-root-project-version2/docker-compose.yml.template
+++ b/src/test/gradle-projects/compose-root-project-version2/docker-compose.yml.template
@@ -1,0 +1,8 @@
+# long-running services
+${project.stackwork.baseComposeStack}
+
+# executable images, will not start during the runDockerCompose task
+  testimage:
+    image: ${project.project(':testimage').stackwork.imageId}
+    links:
+    - service:server

--- a/src/test/gradle-projects/compose-root-project-version2/settings.gradle
+++ b/src/test/gradle-projects/compose-root-project-version2/settings.gradle
@@ -1,0 +1,1 @@
+include 'test', 'testimage'

--- a/src/test/gradle-projects/compose-root-project-version2/test/build.gradle
+++ b/src/test/gradle-projects/compose-root-project-version2/test/build.gradle
@@ -1,0 +1,20 @@
+import static org.stackwork.gradle.docker.ModuleType.*
+
+apply plugin: 'groovy'
+apply plugin: 'stackwork'
+
+stackwork {
+  moduleType = TEST
+  composeProject = project.rootProject
+}
+
+dependencies {
+  compile gradleApi()
+  compile group: 'org.codehaus.groovy', name: 'groovy', version: '2.3.6'
+
+  testCompile group: 'junit', name: 'junit', version: '4.11'
+  testCompile group: 'org.glassfish.jersey.core', name:'jersey-client', version:'2.22'
+  testCompile(group: 'org.spockframework', name: 'spock-core', version: '1.0-groovy-2.4' ) {
+    exclude group: 'org.codehaus.groovy', module: 'groovy-all'
+  }
+}

--- a/src/test/gradle-projects/compose-root-project-version2/test/src/test/groovy/org/stackwork/gradle/docker/test/WebappSpecification.groovy
+++ b/src/test/gradle-projects/compose-root-project-version2/test/src/test/groovy/org/stackwork/gradle/docker/test/WebappSpecification.groovy
@@ -1,0 +1,23 @@
+package org.stackwork.gradle.docker.test
+
+import spock.lang.Specification
+
+import javax.ws.rs.client.ClientBuilder
+
+class WebappSpecification extends Specification {
+
+  def containerHost = System.properties.getProperty('stackwork.service.host')
+  def containerPort = System.properties.getProperty('stackwork.service.port')
+
+  def service = ClientBuilder.newClient().target("http://$containerHost:$containerPort")
+
+  def "We can make a request to a web service running in Docker"() {
+    when:
+    def response = service.path('/').request().buildGet().invoke()
+
+    then:
+    response.status == 200
+    response.readEntity(String.class).trim() == 'Hello world'
+  }
+
+}

--- a/src/test/gradle-projects/compose-root-project-version2/testimage/Dockerfile
+++ b/src/test/gradle-projects/compose-root-project-version2/testimage/Dockerfile
@@ -1,0 +1,4 @@
+# use java:openjdk-8u66-jre as base image because this has curl and we know it is already downloaded
+# for the project's main image, because it is the parent image of qkrijger/wiremock:0.1
+FROM java:openjdk-8u66-jre
+CMD ["wget", "-O-", "--retry-connrefused", "--waitretry", "1", "-t", "10", "server"]

--- a/src/test/gradle-projects/compose-root-project-version2/testimage/build.gradle
+++ b/src/test/gradle-projects/compose-root-project-version2/testimage/build.gradle
@@ -1,0 +1,8 @@
+import static org.stackwork.gradle.docker.ModuleType.*
+
+apply plugin: 'stackwork'
+
+stackwork {
+  moduleType = TEST_IMAGE
+  composeProject = project.rootProject
+}

--- a/src/test/groovy/org/stackwork/gradle/docker/DockerPluginSpecifications.groovy
+++ b/src/test/groovy/org/stackwork/gradle/docker/DockerPluginSpecifications.groovy
@@ -135,6 +135,15 @@ class DockerPluginSpecifications extends Specification {
     output.process.exitValue() == 0
   }
 
+
+	def "The root project can be a Docker Compose module, with a base docker compose stack version 2"() {
+		when:
+		GradleOutput output = runGradleTask('compose-root-project-version2')
+
+		then:
+		output.process.exitValue() == 0
+	}
+
   def "The root project can have a base docker compose stack that can be used by a compose module"() {
     when:
     GradleOutput output = runGradleTask('compose-root-project-compose-module')


### PR DESCRIPTION
Supports docker-compose version 2. Ex.:

version: '2'
services:
  service:
    image: qkrijger/hello-world-wiremock-server:0.1.0-SNAPSHOT
    ports:
    - 80

  testimage:
    image: d7330fed7586
    links:
    - service:server
