### PR TITLE
Remove erroneuous quotes in order to support docker v1.13.0

### DIFF
--- a/src/main/groovy/org/stackwork/gradle/docker/tasks/ExecutableImageRunner.groovy
+++ b/src/main/groovy/org/stackwork/gradle/docker/tasks/ExecutableImageRunner.groovy
@@ -80,7 +80,7 @@ class ExecutableImageRunner {
 
     OutputStream exitCodeOutput = new ByteArrayOutputStream()
     composeProject.exec {
-      setCommandLine(['docker', 'inspect', '-f=\'{{.State.ExitCode}}\'', executableImageProjectStackwork.containerId])
+      setCommandLine(['docker', 'inspect', '-f', '{{.State.ExitCode}}', executableImageProjectStackwork.containerId])
       setStandardOutput exitCodeOutput
     }
     int exitCode = exitCodeOutput.toString().trim() as int

--- a/src/test/gradle-projects/build-templated-dockerfile/build.gradle
+++ b/src/test/gradle-projects/build-templated-dockerfile/build.gradle
@@ -21,7 +21,7 @@ task('inspectImage',
         description: 'Inspect the image. If this works, we know it has been built.',
         group: 'Stackwork',
         type: Exec) {
-  commandLine 'docker', 'inspect', '--format=\'{{.Id}}\'', "${-> project.stackwork.imageId}"
+  commandLine 'docker', 'inspect', '-f', '{{.Id}}', "${-> project.stackwork.imageId}"
 }
 
 tasks.inspectImage.dependsOn tasks.buildImage

--- a/src/test/gradle-projects/build/build.gradle
+++ b/src/test/gradle-projects/build/build.gradle
@@ -19,7 +19,7 @@ task('inspectImage',
         description: 'Inspect the image. If this works, we know it has been built.',
         group: 'Stackwork',
         type: Exec) {
-  commandLine 'docker', 'inspect', '--format=\'{{.Id}}\'', "${-> project.stackwork.imageId}"
+  commandLine 'docker', 'inspect', '-f', '{{.Id}}', "${-> project.stackwork.imageId}"
 }
 
 tasks.inspectImage.dependsOn tasks.buildImage


### PR DESCRIPTION
First and foremost, you should know this project is awesome. Keep up the good work!

When running an executable image for testing, the plugin is unable to correctly fetch the exit code of because the following exception is thrown:
```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':project:runTestImage'.
Caused by: java.lang.NumberFormatException: For input string: "'0'"
        at org.stackwork.gradle.docker.tasks.ExecutableImageRunner.runExecutableImage(ExecutableImageRunner.groovy:86)
        at org.stackwork.gradle.docker.tasks.ExecutableImageRunner.runTestImage(ExecutableImageRunner.groovy:14)
        at org.stackwork.gradle.docker.tasks.ExecutableImageRunner$runTestImage.call(Unknown Source)
        at org.stackwork.gradle.docker.tasks.RunTestImageTask$_closure1.doCall(RunTestImageTask.groovy:21)
        at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:588)
        at org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:569)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:95)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:76)
        ... 69 more
```

This can be easily reproduced by creating a simple build.gradle file with the following contents:
```groovy
task test {
    doLast {
        OutputStream exitCodeOutput = new ByteArrayOutputStream()
        exec {
            setCommandLine(['docker', 'inspect', '-f=\'{{.State.ExitCode}}\'', "STOPPED_CONTAINER"])
            setStandardOutput exitCodeOutput
        }
        println "Exit code: ${exitCodeOutput.toString().trim()}"
        println "The following line will throw an exception: "
        exitCodeOutput.toString().trim() as int
    }
}
```

This is how I fixed it in the branch:
```groovy
task test {
    doLast {
        OutputStream exitCodeOutput = new ByteArrayOutputStream()
        exec {
            setCommandLine(['docker', 'inspect', '-f', '{{.State.ExitCode}}', "STOPPED_CONTAINER"])
            setStandardOutput exitCodeOutput
        }
        println "Exit code: ${exitCodeOutput.toString().trim()}"
    }
}
```

I've confirmed this patch to be working on my build environment.

The cause of the problem is that docker treats single quotes differently in v1.13.0. Also, in some way gradle seems to add quotes to the actual CLI command being executed and I couldn't figure out why. I've tested 4 different versions of docker to confirm.

<details>
<summary>Test results here</summary>

```shell
$ uname -a
Darwin 15.6.0 Darwin Kernel Version 15.6.0: Mon Aug 29 20:21:34 PDT 2016; root:xnu-3248.60.11~1/RELEASE_X86_64 x86_64 i386 MacBookPro11,1 Darwin
$ docker --version
Docker version 1.13.0, build 49bf474
$ docker inspect -f="'{{.State.ExitCode}}'" $STOPPED_CONTAINER
'0'
```
```shell
$ uname -a
Linux 4.4.0-59-generic #80-Ubuntu SMP Fri Jan 6 17:47:47 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
$ docker --version
Docker version 1.13.0, build 49bf474
$ docker inspect -f="'.State.ExitCode'" search_ingester_1
'0'
```
```shell
$ uname -a
Linux 4.9.6-1-ARCH #1 SMP PREEMPT Thu Jan 26 09:22:26 CET 2017 x86_64 GNU/Linux
$ docker --version
Docker version 1.12.6, build 78d18021ec
$ docker inspect -f="'{{.State.ExitCode}}'" $STOPPED_CONTAINER
0
```
```shell
$ uname -a
Linux 4.4.0-57-generic #78-Ubuntu SMP Fri Dec 9 23:50:32 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
$ docker --version
Docker version 1.12.5, build 7392c3b
$ docker inspect -f="'{{.State.ExitCode}}'" $STOPPED_CONTAINER
0
```
```shell
$ uname -a
Linux 3.13.0-44-generic #73-Ubuntu SMP Tue Dec 16 00:22:43 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
$ docker --version
Docker version 1.11.2, build b9f10c9
$ docker inspect -f="'{{.State.ExitCode}}'" $STOPPED_CONTAINER
0
```
</details>